### PR TITLE
fix certbox renewal config

### DIFF
--- a/source/user-manual/wazuh-dashboard/configuring-third-party-certs/ssl.rst
+++ b/source/user-manual/wazuh-dashboard/configuring-third-party-certs/ssl.rst
@@ -206,7 +206,7 @@ Configure the renew_hook using the following steps
       server = https://acme-v02.api.letsencrypt.org/directory
       key_type = rsa
 
-      renew_hook = systemctl restart wazuh-dashboard
+      renew_hook = cp /etc/letsencrypt/live/<YOUR_DOMAIN_NAME>/privkey.pem /etc/letsencrypt/live/<YOUR_DOMAIN_NAME>/fullchain.pem /etc/wazuh-dashboard/certs/; systemctl restart wazuh-dashboard
 
 #. Test the renewal hook by running the command below:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
The certbot renewal config is missing the step to copy the certificate to the wazuh-dashboard directoroy, leading to the cert being automatically renewed, but not installed.
Add the copy step to make certbot install the cert. The permissions will be retained from the previous cert.
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
